### PR TITLE
Fix: calendarHeight

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -43,7 +43,7 @@ class CalendarList extends Component {
   static defaultProps = {
     horizontal: false,
     calendarWidth: width,
-    calendarHeight: 'auto',
+    calendarHeight: 321,
     pastScrollRange: 50,
     futureScrollRange: 50,
     showScrollIndicator: false,


### PR DESCRIPTION
- calendarHeight 값 'auto'에서 321로 수정 
(렌더에 영향을 주는 오류는 아니지만 calendarHeight은 number로 주어야 한다는 경고문이 자꾸 발생하여 수정)